### PR TITLE
ignore changing tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
By using tlib the repo will always report untracked files (specifically doc/tags), this file should be in .gitignore
