### PR TITLE
Added .gitignore to exclude doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Plugin creates a temporary directory located at doc/tags, I added .gitignore to exclude this file.